### PR TITLE
Forcer l'attribut is_private à true lors de la création de la demande…

### DIFF
--- a/lib/redmine_auto_private/hooks.rb
+++ b/lib/redmine_auto_private/hooks.rb
@@ -1,5 +1,17 @@
 module RedmineAutoPrivate
   class Hooks < Redmine::Hook::ViewListener
-    #TODO
+
+    def controller_issues_new_before_save(context={})
+      issue = context[:issue]
+
+      if ((issue.author_id == User.current.id) &&
+         (!((User.current.allowed_to?(:set_own_issues_private, issue.project)) || User.current.allowed_to?(:set_issues_private, issue.project))) &&
+         (issue.project.force_private_issues))
+
+        issue.is_private = true
+      end
+
+    end
+
   end
 end

--- a/spec/controllers/issues_controller_auto_private_spec.rb
+++ b/spec/controllers/issues_controller_auto_private_spec.rb
@@ -31,4 +31,51 @@ describe IssuesController, :type => :controller  do
     assert_select "input[name='issue[is_private]'][type='checkbox']", false
     assert_select "input[name='issue[is_private]'][type='hidden'][value='1']"
   end
+
+  describe "create issue when a user who does not have the permission to create it" do
+
+    it "Should set the issue as private if auto-private flag is activated" do
+      Role.find(1).remove_permission!(:set_issues_private)
+      Project.find(1).update_attribute(:force_private_issues, true)
+      expect {
+        post(
+              :create,
+              :params => {
+                :project_id => 1,
+                :issue => {
+                  :tracker_id => 1,
+                  :status_id => 2,
+                  :subject => 'test issue as private',
+                  :priority_id => 5,
+                  :start_date => '2022-01-25'
+                }
+              }
+        )
+      }.to change { Issue.count }.by(1)
+
+      expect(Issue.last().is_private).to be true
+    end
+
+    it "Should not set the issue as private if auto-private flag is inactivated" do
+      Role.find(1).remove_permission!(:set_issues_private)
+      expect {
+        post(
+              :create,
+              :params => {
+                :project_id => 1,
+                :issue => {
+                  :tracker_id => 1,
+                  :status_id => 2,
+                  :subject => 'test issue as not private',
+                  :priority_id => 5,
+                  :start_date => '2022-01-25'
+                }
+              }
+        )
+      }.to change { Issue.count }.by(1)
+
+      expect(Issue.last().is_private).to be false
+    end
+
+  end
 end


### PR DESCRIPTION
-  Forcer l'attribut is_private à true lors de la création de la demande, même si l'utilisateur n'a pas cette permission
- Implémentation des tests